### PR TITLE
Add custom Golang server with timeout

### DIFF
--- a/config.go
+++ b/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 )
 
 //Config represents the configuration of the entire application. All configuration
@@ -25,11 +26,26 @@ type GeneralConfig struct {
 	Domain string `json:"domain"`
 	//Debug will turn on verbose logging and print out configuration parameters.
 	Logger LogConfig `json:"logger"`
+	//ReadTimeout configures the HTTP timeout for reading a request body
+	ReadTimeout time.Duration
+	//WriteTimeout configures the HTTP timeout for writing a response body
+	WriteTimeout time.Duration
+	//IdleTimeout configures the HTTP timeout for TCP keep-alive
+	IdleTimeout time.Duration
 }
 
 func (c GeneralConfig) validate() error {
 	if c.Location == "" {
 		return errors.New("general config missing required location field")
+	}
+	if c.ReadTimeout == 0 {
+		c.ReadTimeout = 5 * time.Second
+	}
+	if c.WriteTimeout == 0 {
+		c.WriteTimeout = 10 * time.Second
+	}
+	if c.IdleTimeout == 0 {
+		c.IdleTimeout = 120 * time.Second
 	}
 	return nil
 }

--- a/config_test.go
+++ b/config_test.go
@@ -14,7 +14,10 @@ var completeConfig = `
 			"debug": true,
 			"file": "cxmate.log",
 			"format": "json"
-		}
+		},
+		"ReadTimeout": 1,
+		"WriteTimeout": 2,
+		"IdleTimeout": 3
 	},
 	"service": {
 		"location": "localhost:8080",
@@ -57,7 +60,16 @@ func TestLoadConfig(t *testing.T) {
 		t.Error("config.General.Logger.File not set")
 	}
 	if config.General.Logger.Format != "json" {
-		t.Error("config.General.Format not set")
+		t.Error("config.General.Logger.Format not set")
+	}
+	if config.General.ReadTimeout != 1 {
+		t.Error("config.General.ReadTimeout not set")
+	}
+	if config.General.WriteTimeout != 2 {
+		t.Error("config.General.WriteTimeout not set")
+	}
+	if config.General.IdleTimeout != 3 {
+		t.Error("config.General.IdleTimeout not set")
 	}
 	if config.Service.Location != "localhost:8080" {
 		t.Error("config.Service.Location not set")

--- a/main.go
+++ b/main.go
@@ -127,8 +127,15 @@ func main() {
 	}
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", cxmate.handleRoot)
+	srv := &http.Server{
+		Addr:         cxmate.Config.General.Location,
+		ReadTimeout:  cxmate.Config.General.ReadTimeout,
+		WriteTimeout: cxmate.Config.General.WriteTimeout,
+		IdleTimeout:  cxmate.Config.General.IdleTimeout,
+		Handler:      mux,
+	}
 	cxmate.Logger.Infoln("cxMate now listening on", cxmate.Config.General.Location, "connected to service on", cxmate.Config.Service.Location)
-	logFatalln(http.ListenAndServe(cxmate.Config.General.Location, mux))
+	logFatalln(srv.ListenAndServe())
 }
 
 //WriteDetector determines if a write has been made to a writer


### PR DESCRIPTION
This closes #3. Timeouts can be customized in the cxmate.json or a default will be supplied to the net/http Server struct which has replaced the default http server. 