### PR TITLE
Fix Dockerfile WORKDIR

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,4 +5,6 @@ COPY . .
 
 RUN go-wrapper install
 
+WORKDIR /cxmate
+
 CMD ["cxmate"]


### PR DESCRIPTION
This closes #10, WORKDIR is now pointing to the correct directory.